### PR TITLE
Change: default backend for the scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - minor fixes in documentation typos and argument names.
 - `Domain` is moved from `hypertunity.optimisation` to the `hypertunity` package.
 - rename `TableReporter` to `Table` and `TensorboardReporter` to `Tensorboard`.
+- backed for the `Scheduler` is reverted to 'loky' as leaking semaphore errors have disappeared.
 
 ## [0.4.0] - 2019-09-15
 ## Added

--- a/hypertunity/scheduling/scheduler.py
+++ b/hypertunity/scheduling/scheduler.py
@@ -64,7 +64,7 @@ class Scheduler:
             written to the result queue.
         """
         # TODO: Switch backend back to default "loky", after the leakage of semaphores is fixed
-        with joblib.Parallel(n_jobs=self.n_parallel, backend="multiprocessing") as parallel:
+        with joblib.Parallel(n_jobs=self.n_parallel, backend="loky") as parallel:
             while not self._interrupt_event.is_set():
                 current_jobs = utils.drain_queue(self._job_queue)
                 if not current_jobs:


### PR DESCRIPTION
Changed back to loky as the errors for the leaking semaphores are not present anymore.