### PR TITLE
Fix failing docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,3 @@ python:
         path: .
         extra_requirements:
             - docs
-            - tensorboard

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ napoleon_use_keyword = True
 napoleon_use_rtype = True
 
 autodoc_typehints = 'none'
+autodoc_mock_imports = ['tensorflow', 'tensorboard']
 
 
 source_suffix = '.rst'

--- a/hypertunity/reports/tensorboard.py
+++ b/hypertunity/reports/tensorboard.py
@@ -18,15 +18,13 @@ except ImportError as err:
                       "to support the HParams plugin.") from err
 
 
-
-
 __all__ = [
     "Tensorboard"
 ]
 
 EAGER_MODE = tf.executing_eagerly()
 session_builder = tf.compat.v1.Session
-if tf.version.VERSION < "2.":
+if str(tf.version.VERSION) < "2.":
     summary_file_writer = tf.compat.v2.summary.create_file_writer
     summary_scalar = tf.compat.v2.summary.scalar
 else:


### PR DESCRIPTION
Remove the dependency on tensorflow and tensorboard from the docs build config. Mock the dependencies and fix an issue with tensorflow 2.1 version comparison.